### PR TITLE
Fix issue causing segmentation fault

### DIFF
--- a/surreal/env/__init__.py
+++ b/surreal/env/__init__.py
@@ -4,5 +4,5 @@ from .atari_wrappers import *
 from .exp_sender_wrapper import *
 from .monitor import *
 from .wrapper import *
-from .make_env import make_env
+from .make_env import make_env, make_env_config
 from .video_env import VideoWrapper

--- a/surreal/env/make_env.py
+++ b/surreal/env/make_env.py
@@ -1,4 +1,5 @@
 import os
+import gc
 from surreal.env.video_env import VideoWrapper
 import surreal.utils as U
 from .wrapper import (
@@ -12,13 +13,26 @@ from .wrapper import (
     )
 
 
+def make_env_config(env_config, mode=None):
+    """
+    Same as make_env, but explicitly deallocates the environment to avoid 
+    further complications
+
+    Returns:
+        Populated env_config
+    """
+    env, env_config = make_env(env_config, mode)
+    del env
+    gc.collect()
+    return env_config
+
+
 def make_env(env_config, mode=None):
     """
     Makes an environment and populates related fields in env_config
     return env, env_config
     Args:
-        overrides(str): point to the override in env_config to 
-                        provide differnt kwargs to the initializer of the environment
+        mode(str): allow differnt kwargs to the initializer of the environment
     """
     env_name = env_config.env_name
     env_category, env_name = env_name.split(':')

--- a/surreal/env/make_env.py
+++ b/surreal/env/make_env.py
@@ -15,7 +15,18 @@ from .wrapper import (
 
 def make_env_config(env_config, mode=None):
     """
-    Same as make_env, but explicitly deallocates the environment to avoid 
+    Issue: Surreal-tmux gives segfault on running robosuite environments.
+    Cause: On launching a surreal process, an instance of RL environment is
+        created to obtain observation and action dimension info. This
+        environment can hold reference to openGL context that is not safe
+        for multiprocessing. The environment is dereferenced but not
+        necessarily garbage collected before fork/exec happens,
+        causing memory issues.
+    Solution: make_env_config method deallocates the environment and explicitly
+    calls the garbage collector. Use this method to obtain observation and
+        action dimensions.
+
+    Same as make_env, but explicitly deallocates the environment to avoid
     further complications
 
     Returns:

--- a/surreal/main/ddpg_configs.py
+++ b/surreal/main/ddpg_configs.py
@@ -9,7 +9,7 @@ from surreal.agent import DDPGAgent
 from surreal.learner import DDPGLearner
 from surreal.replay import UniformReplay
 from surreal.launch import SurrealDefaultLauncher
-from surreal.env import make_env
+from surreal.env import make_env_config
 
 # TODO：Documentation on config files
 
@@ -269,22 +269,8 @@ class DDPGLauncher(SurrealDefaultLauncher):
 
         args = parser.parse_args(args=argv)
 
-        if args.env == 'robosuite:SawyerLift':
-            learner_class = DDPGLearner
-            agent_class = DDPGAgent
-            replay_class = UniformReplay
-            learner_config = DDPG_BLOCK_LIFTING_LEARNER_CONFIG
-            env_config = DDPG_BLOCK_LIFTING_ENV_CONFIG
-            session_config = DDPG_DEFAULT_SESSION_CONFIG
-            super.__init__(agent_class,
-                           learner_class,
-                           replay_class,
-                           session_config,
-                           env_config,
-                           learner_config)
-
         self.env_config.env_name = args.env
-        _, self.env_config = make_env(self.env_config)
+        self.env_config = make_env_config(self.env_config)
         self.env_config.num_agents = args.num_agents
 
         self.session_config.folder = args.experiment_folder

--- a/surreal/main/ppo_configs.py
+++ b/surreal/main/ppo_configs.py
@@ -8,7 +8,7 @@ from surreal.agent import PPOAgent
 from surreal.learner import PPOLearner
 from surreal.replay import FIFOReplay
 from surreal.launch import SurrealDefaultLauncher
-from surreal.env import make_env
+from surreal.env import make_env, make_env_config
 import argparse
 
 
@@ -211,7 +211,7 @@ class PPOLauncher(SurrealDefaultLauncher):
         args = parser.parse_args(args=argv)
 
         self.env_config.env_name = args.env
-        _, self.env_config = make_env(self.env_config)
+        self.env_config = make_env_config(self.env_config)
 
         self.session_config.folder = args.experiment_folder
         self.session_config.agent.num_gpus = args.agent_num_gpus


### PR DESCRIPTION
Issue: Surreal-tmux gives segfault on running robosuite environments.
Cause: On launching a surreal process, an instance of RL environment is created to obtain observation and action dimension info. This environment can hold reference to openGL context that is not safe for multiprocessing. The environment is dereferenced but not necessarily garbage collected before fork/exec happens, causing memory issues.
Solution: `make_env_config` method deallocates the environment and explicitly calls the garbage collector. Use this method to obtain observation and action dimensions.