### PR TITLE
fix import ordering in utils

### DIFF
--- a/surreal/utils/__init__.py
+++ b/surreal/utils/__init__.py
@@ -1,7 +1,7 @@
+from .checkpoint import Checkpoint, PeriodicCheckpoint
+from .config_yaml import get_config_file
 from .common import *
 from .numpy_util import *
 from .schedule import *
 from .filesys import *
 from .serializer import *
-from .checkpoint import Checkpoint, PeriodicCheckpoint
-from .config_yaml import get_config_file


### PR DESCRIPTION
Fixes segfault on Ubuntu encountered on `from surreal.env import *`. Tested on the B36 Ubuntu machine.